### PR TITLE
Add a simple application security function

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,8 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+	// spring security dependencies
+	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("com.h2database:h2")
 	implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/java/com/microsoft/shinyay/demo/config/SecurityConfig.java
+++ b/src/main/java/com/microsoft/shinyay/demo/config/SecurityConfig.java
@@ -1,0 +1,23 @@
+package com.microsoft.shinyay.demo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeRequests(authorizeRequests -> authorizeRequests
+                        .anyRequest()
+                        .permitAll())
+                .csrf(AbstractHttpConfigurer::disable);
+        return http.build();
+    }
+}


### PR DESCRIPTION
This pull request introduces a new security configuration for the application. The most important change includes adding a new `SecurityConfig` class to configure HTTP security settings.

Security Configuration:

* [`src/main/java/com/microsoft/shinyay/demo/config/SecurityConfig.java`](diffhunk://#diff-bc3f341e5ba3bfe7fa990866b44c53d47e5510442438d82e93375e6ebc4829ffR1-R23): Added a new `SecurityConfig` class that configures the security filter chain to permit all requests and disables CSRF protection.