### PR TITLE
Simple persistence

### DIFF
--- a/src/main/java/com/microsoft/shinyay/demo/DemoApplication.java
+++ b/src/main/java/com/microsoft/shinyay/demo/DemoApplication.java
@@ -2,10 +2,12 @@ package com.microsoft.shinyay.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 public class DemoApplication {
 
+	@EnableJpaRepositories(basePackages = "com.microsoft.shinyay.demo.repository")
 	public static void main(String[] args) {
 		SpringApplication.run(DemoApplication.class, args);
 	}

--- a/src/main/java/com/microsoft/shinyay/demo/DemoApplication.java
+++ b/src/main/java/com/microsoft/shinyay/demo/DemoApplication.java
@@ -3,11 +3,13 @@ package com.microsoft.shinyay.demo;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 
 @SpringBootApplication
 public class DemoApplication {
 
 	@EnableJpaRepositories(basePackages = "com.microsoft.shinyay.demo.repository")
+	@EntityScan(basePackages = "com.microsoft.shinyay.demo.entity")
 	public static void main(String[] args) {
 		SpringApplication.run(DemoApplication.class, args);
 	}

--- a/src/main/java/com/microsoft/shinyay/demo/entity/Book.java
+++ b/src/main/java/com/microsoft/shinyay/demo/entity/Book.java
@@ -11,4 +11,8 @@ import javax.persistence.Entity;
 @Entity
 public class Book {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
 }

--- a/src/main/java/com/microsoft/shinyay/demo/entity/Book.java
+++ b/src/main/java/com/microsoft/shinyay/demo/entity/Book.java
@@ -1,0 +1,14 @@
+package com.microsoft.shinyay.demo.entity;
+
+import javax.persistence.Entity;
+// I will create a entity class for a book
+// This class will be used to represent a book in the database
+// The database will be created automatically by Spring Data JPA
+// The database will be an in-memory database
+// The database will be H2
+// The database will be created in the file system
+
+@Entity
+public class Book {
+
+}

--- a/src/main/java/com/microsoft/shinyay/demo/entity/Book.java
+++ b/src/main/java/com/microsoft/shinyay/demo/entity/Book.java
@@ -15,4 +15,6 @@ public class Book {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
+    @Column(name = "title", length = 255, nullable = false)
+    private String title;
 }

--- a/src/main/java/com/microsoft/shinyay/demo/entity/Book.java
+++ b/src/main/java/com/microsoft/shinyay/demo/entity/Book.java
@@ -17,4 +17,7 @@ public class Book {
 
     @Column(name = "title", length = 255, nullable = false)
     private String title;
+
+    @Column(name = "author", length = 255, nullable = false)
+    private String author;
 }

--- a/src/main/java/com/microsoft/shinyay/demo/entity/Book.java
+++ b/src/main/java/com/microsoft/shinyay/demo/entity/Book.java
@@ -1,12 +1,12 @@
 package com.microsoft.shinyay.demo.entity;
 
 import javax.persistence.Entity;
-// I will create a entity class for a book
-// This class will be used to represent a book in the database
-// The database will be created automatically by Spring Data JPA
-// The database will be an in-memory database
-// The database will be H2
-// The database will be created in the file system
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Column;
+
 
 @Entity
 public class Book {

--- a/src/main/java/com/microsoft/shinyay/demo/repository/BookRepository.java
+++ b/src/main/java/com/microsoft/shinyay/demo/repository/BookRepository.java
@@ -1,0 +1,5 @@
+package com.microsoft.shinyay.demo.repository;
+
+public interface BookRepository {
+
+}

--- a/src/main/java/com/microsoft/shinyay/demo/repository/BookRepository.java
+++ b/src/main/java/com/microsoft/shinyay/demo/repository/BookRepository.java
@@ -1,5 +1,5 @@
 package com.microsoft.shinyay.demo.repository;
 
 public interface BookRepository extends CrudRepository<Book, Long> {
-
+    List<Book> findByTitle(String title);
 }

--- a/src/main/java/com/microsoft/shinyay/demo/repository/BookRepository.java
+++ b/src/main/java/com/microsoft/shinyay/demo/repository/BookRepository.java
@@ -1,5 +1,5 @@
 package com.microsoft.shinyay.demo.repository;
 
-public interface BookRepository {
+public interface BookRepository extends CrudRepository<Book, Long> {
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,4 @@ spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALS
 spring.datasource.username=sa
 spring.datasource.password=
 spring.datasource.platform=h2
+spring.h2.console.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,4 @@ spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.username=sa
 spring.datasource.password=
+spring.datasource.platform=h2

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,4 +13,6 @@ spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALS
 spring.datasource.username=sa
 spring.datasource.password=
 spring.datasource.platform=h2
+# H2 Console
 spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,6 @@ spring.thymeleaf.cache=false
 spring.thymeleaf.enabled=true
 spring.thymeleaf.prefix=classpath:/templates/
 spring.thymeleaf.suffix=.html
+
+# H2
+spring.datasource.driver-class-name=org.h2.Driver

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,6 @@ spring.thymeleaf.suffix=.html
 
 # H2
 spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.username=sa
+spring.datasource.password=


### PR DESCRIPTION
This pull request introduces several significant changes to the `DemoApplication` project, including enabling JPA repositories, defining a new entity, and configuring a repository interface. Additionally, it includes updates to the application properties for H2 database configuration.

### JPA Integration and Entity Setup:

* [`src/main/java/com/microsoft/shinyay/demo/DemoApplication.java`](diffhunk://#diff-309cd90a007a6b33025bf47ce94efdcc09805b9e0a6c7e511c01e862e4cc376bR5-R12): Enabled JPA repositories and entity scanning by adding `@EnableJpaRepositories` and `@EntityScan` annotations.
* [`src/main/java/com/microsoft/shinyay/demo/entity/Book.java`](diffhunk://#diff-a841e02741a7591c6755eef0296017f81706cb597ebbd4ee40dbd7ed9a2d5c01R1-R23): Added a new `Book` entity with fields for `id`, `title`, and `author`, and annotated it with JPA annotations.

### Repository Setup:

* [`src/main/java/com/microsoft/shinyay/demo/repository/BookRepository.java`](diffhunk://#diff-7ba0be890a7e690761f4bcd019b05898d277f49e496ca9e424ba55d647204d5aR1-R5): Created a `BookRepository` interface extending `CrudRepository` to handle `Book` entities.

### Database Configuration:

* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136R9-R18): Configured an H2 in-memory database and enabled the H2 console for local development.

### Related Issues
- #3 
- #8 